### PR TITLE
Change base image to testing and disable mesa install

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,10 +115,19 @@ jobs:
       - name: Build image (rootful)
         id: build_image
         run: |
+          FEDORA_VER=$(skopeo inspect docker://ghcr.io/ublue-os/bazzite-gnome:testing 2>/dev/null \
+            | jq -r '.Labels["org.opencontainers.image.version"] // empty' \
+            | grep -oP '^\d+' || echo "44")
+          VERSION_DATE=$(date -u +%Y%m%d)
           # Builds image in root store as root, to be picked up by Rechunker
           sudo buildah bud \
             --format docker \
             --tag "localhost/${IMAGE_NAME}:${{ env.DEFAULT_TAG }}" \
+            --build-arg IMAGE_NAME="${IMAGE_NAME}" \
+            --build-arg IMAGE_VENDOR="${{ github.repository_owner }}" \
+            --build-arg IMAGE_BRANCH="${{ github.ref_name }}" \
+            --build-arg BASE_IMAGE_NAME="bazzite-gnome" \
+            --build-arg VERSION_DATE="${VERSION_DATE}" \
             --file Containerfile \
             .
 

--- a/Containerfile
+++ b/Containerfile
@@ -14,7 +14,7 @@ FROM ghcr.io/ublue-os/bazzite-gnome:testing as DistinctionOS
 # Copy pre-built mesa RPMs into the image so 05-mesa-install.sh can install them
 # NOTE: must NOT be under /tmp — the main RUN step mounts /tmp as tmpfs, which
 # would shadow anything COPY'd there.
-COPY --from=mesa-rpms /rpms/ /var/tmp/mesa-rpms/
+#COPY --from=mesa-rpms /rpms/ /var/tmp/mesa-rpms/
 
 
 # Cleanup & Finalize

--- a/Containerfile
+++ b/Containerfile
@@ -5,10 +5,10 @@ COPY build_files /
 # Pre-built custom mesa stack — Fedora SRPM + freeworld codec patches applied.
 # Built by .github/workflows/build-mesa.yml, published weekly to GHCR.
 # All subpackages come from one SRPM so versions are guaranteed in sync.
-FROM ghcr.io/phantomcortex/distinctionos-mesa:latest AS mesa-rpms
+#FROM ghcr.io/phantomcortex/distinctionos-mesa:latest AS mesa-rpms
 
 # Base Image
-FROM ghcr.io/ublue-os/bazzite-gnome:stable as DistinctionOS
+FROM ghcr.io/ublue-os/bazzite-gnome:testing as DistinctionOS
 #FROM quay.io/fedora/fedora-bootc:42
 
 # Copy pre-built mesa RPMs into the image so 05-mesa-install.sh can install them
@@ -33,8 +33,6 @@ RUN --mount=type=bind,from=ctx,source=/,target=/ctx \
     /ctx/03-fix-opt.sh && \
     echo -e "\033[31mSYSTEM CONFIG >>>>\033[0m" && \
     /ctx/04-config.sh && \
-    echo -e "\033[31mMESA INSTALL >>>>\033[0m" && \
-    /ctx/05-mesa-install.sh && \
     echo -e "\033[31mREMOTE GRABBER >>>>\033[0m" && \
     /ctx/06-remote-grabber.sh && \
     echo -e "\033[31mOSTREE COMMIT\033[0m" && \
@@ -44,4 +42,4 @@ RUN --mount=type=bind,from=ctx,source=/,target=/ctx \
     
 ### LINTING
 ## Verify final image and contents are correct.
-#RUN bootc container lint
+RUN bootc container lint

--- a/Containerfile
+++ b/Containerfile
@@ -23,10 +23,6 @@ RUN --mount=type=bind,from=ctx,source=/,target=/ctx \
     --mount=type=cache,dst=/var/cache \
     --mount=type=cache,dst=/var/log \
     --mount=type=tmpfs,dst=/tmp \
-    echo -e "\033[31mKERNEL INSTALLER >>>>\033[0m" && \
-    /ctx/00-kernel.sh && \
-    echo -e "\033[31mKERNEL MODULES >>>>\033[0m" && \
-    /ctx/01-kernel-modules.sh && \
     echo -e "\033[31mBUILD SCRIPT >>>>\033[0m" && \
     /ctx/02-build.sh && \
     echo -e "\033[31mOPT FIXER >>>>\033[0m" && \

--- a/Containerfile
+++ b/Containerfile
@@ -11,6 +11,12 @@ COPY build_files /
 FROM ghcr.io/ublue-os/bazzite-gnome:testing as DistinctionOS
 #FROM quay.io/fedora/fedora-bootc:42
 
+ARG IMAGE_NAME="distinctionos"
+ARG IMAGE_VENDOR="phantomcortex"
+ARG IMAGE_BRANCH="main"
+ARG BASE_IMAGE_NAME="bazzite-gnome"
+ARG VERSION_DATE="00000000"
+
 # Copy pre-built mesa RPMs into the image so 05-mesa-install.sh can install them
 # NOTE: must NOT be under /tmp — the main RUN step mounts /tmp as tmpfs, which
 # would shadow anything COPY'd there.
@@ -31,6 +37,8 @@ RUN --mount=type=bind,from=ctx,source=/,target=/ctx \
     /ctx/04-config.sh && \
     echo -e "\033[31mREMOTE GRABBER >>>>\033[0m" && \
     /ctx/06-remote-grabber.sh && \
+    echo -e "\033[31mIMAGE INFO >>>>\033[0m" && \
+    /ctx/image-info && \
     echo -e "\033[31mOSTREE COMMIT\033[0m" && \
     ostree container commit
 

--- a/build_files/image-info
+++ b/build_files/image-info
@@ -1,0 +1,92 @@
+#!/usr/bin/bash
+
+set -eoux pipefail
+
+IMAGE_PRETTY_NAME="DistinctionOS"
+IMAGE_LIKE="fedora"
+HOME_URL="https://github.com/phantomcortex/DistinctionOS"
+DOCUMENTATION_URL="https://github.com/phantomcortex/DistinctionOS/wiki"
+SUPPORT_URL="https://github.com/phantomcortex/DistinctionOS/discussions"
+BUG_SUPPORT_URL="https://github.com/phantomcortex/DistinctionOS/issues/"
+LOGO_ICON="bazzite-logo-icon"
+LOGO_COLOR="0;38;2;138;43;226"
+
+IMAGE_INFO="/usr/share/ublue-os/image-info.json"
+IMAGE_REF="ostree-image-signed:docker://ghcr.io/${IMAGE_VENDOR}/${IMAGE_NAME}"
+
+FEDORA_VERSION=$(rpm -E %fedora)
+VERSION_TAG="${FEDORA_VERSION}.${VERSION_DATE}.0"
+
+# Preserve VERSION_CODENAME from the base Bazzite os-release before modifying
+VERSION_CODENAME=$(grep "^VERSION_CODENAME=" /usr/lib/os-release | cut -d'"' -f2 || echo "Silverblue")
+
+# Map branch to release type: main -> latest, everything else -> testing
+if [[ "$IMAGE_BRANCH" == "main" ]]; then
+    RELEASE_TYPE="latest"
+else
+    RELEASE_TYPE="testing"
+fi
+
+# Human-readable label used in BUILD_ID and BOOTLOADER_NAME
+if [[ "$RELEASE_TYPE" == "latest" ]]; then
+    VERSION_LABEL="Latest"
+else
+    VERSION_LABEL="Testing"
+fi
+VERSION_PRETTY="${VERSION_LABEL} (F${FEDORA_VERSION}.${VERSION_DATE})"
+
+# Write image-info.json (read by ublue tooling)
+cat > "$IMAGE_INFO" <<EOF
+{
+  "image-name": "$IMAGE_NAME",
+  "image-vendor": "$IMAGE_VENDOR",
+  "image-ref": "$IMAGE_REF",
+  "image-tag": "$RELEASE_TYPE",
+  "image-branch": "$IMAGE_BRANCH",
+  "base-image-name": "$BASE_IMAGE_NAME",
+  "fedora-version": "$FEDORA_VERSION",
+  "version": "$VERSION_TAG",
+  "version-pretty": "$VERSION_PRETTY"
+}
+EOF
+
+# Rebrand /usr/lib/os-release from Bazzite to DistinctionOS
+# Input is already Bazzite-processed os-release (ID=bazzite, etc.)
+sed -i "s/^NAME=.*/NAME=\"$IMAGE_PRETTY_NAME\"/" /usr/lib/os-release
+sed -i "s/^PRETTY_NAME=.*/PRETTY_NAME=\"$IMAGE_PRETTY_NAME\"/" /usr/lib/os-release
+sed -i "s/^VERSION=.*/VERSION=\"$VERSION_TAG ($VERSION_CODENAME)\"/" /usr/lib/os-release
+sed -i "s/^RELEASE_TYPE=.*/RELEASE_TYPE=$RELEASE_TYPE/" /usr/lib/os-release
+sed -i "s|^HOME_URL=.*|HOME_URL=\"$HOME_URL\"|" /usr/lib/os-release
+sed -i "s|^DOCUMENTATION_URL=.*|DOCUMENTATION_URL=\"$DOCUMENTATION_URL\"|" /usr/lib/os-release
+sed -i "s|^SUPPORT_URL=.*|SUPPORT_URL=\"$SUPPORT_URL\"|" /usr/lib/os-release
+sed -i "s|^BUG_REPORT_URL=.*|BUG_REPORT_URL=\"$BUG_SUPPORT_URL\"|" /usr/lib/os-release
+sed -i "s|^CPE_NAME=.*|CPE_NAME=\"cpe:/o:phantomcortex:${IMAGE_PRETTY_NAME,}:${FEDORA_VERSION}\"|" /usr/lib/os-release
+sed -i "s/^DEFAULT_HOSTNAME=.*/DEFAULT_HOSTNAME=\"${IMAGE_PRETTY_NAME,}\"/" /usr/lib/os-release
+sed -i "s/^LOGO=.*/LOGO=$LOGO_ICON/" /usr/lib/os-release
+sed -i "s/^ANSI_COLOR=.*/ANSI_COLOR=\"$LOGO_COLOR\"/" /usr/lib/os-release
+
+echo "$IMAGE_PRETTY_NAME release $FEDORA_VERSION" > /etc/system-release
+
+if grep -q '^BUILD_ID=' /usr/lib/os-release; then
+    sed -i "s/^BUILD_ID=.*/BUILD_ID=\"$VERSION_PRETTY\"/" /usr/lib/os-release
+else
+    echo "BUILD_ID=\"$VERSION_PRETTY\"" >> /usr/lib/os-release
+fi
+
+if grep -q '^BOOTLOADER_NAME=' /usr/lib/os-release; then
+    sed -i "s/^BOOTLOADER_NAME=.*/BOOTLOADER_NAME=\"$IMAGE_PRETTY_NAME $VERSION_PRETTY\"/" /usr/lib/os-release
+else
+    echo "BOOTLOADER_NAME=\"$IMAGE_PRETTY_NAME $VERSION_PRETTY\"" >> /usr/lib/os-release
+fi
+
+if grep -q '^IMAGE_ID=' /usr/lib/os-release; then
+    sed -i "s/^IMAGE_ID=.*/IMAGE_ID=\"$IMAGE_NAME-$VERSION_TAG\"/" /usr/lib/os-release
+else
+    echo "IMAGE_ID=\"$IMAGE_NAME-$VERSION_TAG\"" >> /usr/lib/os-release
+fi
+
+if grep -q '^OSTREE_VERSION=' /usr/lib/os-release; then
+    sed -i "s/^OSTREE_VERSION=.*/OSTREE_VERSION='$VERSION_TAG'/" /usr/lib/os-release
+else
+    echo "OSTREE_VERSION='$VERSION_TAG'" >> /usr/lib/os-release
+fi


### PR DESCRIPTION
- Remove Custom mesa RPMs
- Remove CachyOS-LTO kernel

Adds build_files/image-info (modeled on Bazzite's equivalent) that
rewrites /usr/lib/os-release during the image build: replaces all
Bazzite branding with DistinctionOS, sets VERSION/OSTREE_VERSION to
the current build date, and maps the git branch to RELEASE_TYPE
(main -> latest, everything else -> testing).

Containerfile gains five ARGs (IMAGE_NAME, IMAGE_VENDOR, IMAGE_BRANCH,
BASE_IMAGE_NAME, VERSION_DATE) and calls /ctx/image-info before the
ostree commit. build.yml passes those args to buildah bud, deriving
VERSION_DATE from the CI run date and the Fedora major version from the
base image label.
