### PR TITLE
Match Bazzite's build pipeline: native chunker + BTRFS storage

### DIFF
--- a/.github/workflows/build-disk.yml
+++ b/.github/workflows/build-disk.yml
@@ -96,7 +96,7 @@ jobs:
           retention-days: 0
           compression-level: 0
           overwrite: true
-      
+
       - name: Upload to S3
         if: inputs.upload-to-s3 == true && github.event_name != 'pull_request'
         shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,10 +19,6 @@ on:
       - 'system_files/**' # modifcations to system files are usually small and don't warrant a full rebuild
   workflow_dispatch:
     inputs:
-      fresh-rechunk:
-        description: 'Clear rechunk history (forces full redownload for users)'
-        type: boolean
-        default: false
       handwritten:
         description: 'Optional handwritten changelog message for this release'
         type: string
@@ -171,6 +167,26 @@ jobs:
           docker-images: false
           swap-storage: true
 
+      # GHA runners ship with a small root partition and a much larger
+      # ephemeral /mnt. Default overlay-on-ext4 storage saturates root
+      # disk headroom mid-chunk on big layered images; switching
+      # /var/lib/containers to BTRFS on /mnt buys us the headroom and
+      # lets the chunker use reflinks instead of full file copies.
+      - name: Check if /mnt is mounted
+        id: check_mnt
+        run: |
+          if sudo mountpoint /mnt; then
+            echo "mnt_is_there=1" >> "$GITHUB_OUTPUT"
+          else
+            echo "mnt_is_there=0" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Mount BTRFS for podman storage
+        uses: ublue-os/container-storage-action@main
+        if: ${{ steps.check_mnt.outputs.mnt_is_there == '1' }}
+        with:
+          target-dir: /var/lib/containers
+
       - name: Build image (rootful)
         id: build_image
         run: |
@@ -202,70 +218,65 @@ jobs:
             echo "No images to remove."
           fi
 
-      - name: Run Rechunker
-        id: rechunk
-        uses: hhd-dev/rechunk@v1.2.4
+      # The native chunker (rpm-ostree compose build-chunked-oci) doesn't
+      # accept --label, so labels and annotations have to be baked into
+      # the raw image before chunking. metadata-action emits labels
+      # newline-separated by default; we apply each via `buildah config`.
+      - name: Apply OCI labels to raw image
         if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
-        with:
-          rechunk: "ghcr.io/hhd-dev/rechunk:v1.2.3"
-          ref: "localhost/${{ env.IMAGE_NAME }}:${{ env.DEFAULT_TAG }}"
-          prev-ref: "${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.DEFAULT_TAG }}"
-          skip_compression: false
-          max-layers: 90
-          labels: ${{ steps.metadata.outputs.labels }} # Rechunk strips out all the labels during build, this needs to be reapplied here with newline separator
-
-      - name: Remove Rechunker image
-        run: |
-          image=$(sudo podman images -n --sort repository --format '{{.ID}} {{.Repository}}' | grep rechunk | awk '{print $1}')
-          if [ -n "${image}" ]; then
-            sudo podman rmi --force "$image"
-          else
-            echo "No image to remove"
-          fi
-
-      - name: Rechunk output
-        continue-on-error: true
-        if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
-        run: |
-          if [[ "${STEPS_RECHUNK_CONCLUSION}" == "success" ]]; then
-            echo "=== Rechunk Changelog ==="
-            if [ -f "${STEPS_RECHUNK_OUTPUTS_CHANGELOG}" ]; then
-              cat "${STEPS_RECHUNK_OUTPUTS_CHANGELOG}"
-            fi
-            echo ""
-            echo "=== Rechunk Manifest ==="
-            if [ -f "${STEPS_RECHUNK_OUTPUTS_MANIFEST}" ]; then
-              cat "${STEPS_RECHUNK_OUTPUTS_MANIFEST}"
-            fi
-          else
-            echo "Rechunk conclusion: ${STEPS_RECHUNK_CONCLUSION}"
-          fi
         env:
-          STEPS_RECHUNK_CONCLUSION: ${{ steps.rechunk.conclusion }}
-          STEPS_RECHUNK_OUTPUTS_CHANGELOG: ${{ steps.rechunk.outputs.changelog }}
-          STEPS_RECHUNK_OUTPUTS_MANIFEST: ${{ steps.rechunk.outputs.manifest }}
-
-      - name: Load in podman and tag
-        if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
-        run: |
-          IMAGE=$(podman pull ${STEPS_RECHUNK_OUTPUTS_REF})
-          sudo rm -rf ${STEPS_RECHUNK_OUTPUTS_LOCATION}
-          for tag in ${STEPS_METADATA_OUTPUTS_TAGS}; do
-            podman tag $IMAGE ${IMAGE_NAME}:$tag
-          done
-        env:
-          STEPS_RECHUNK_OUTPUTS_REF: ${{ steps.rechunk.outputs.ref }}
-          STEPS_RECHUNK_OUTPUTS_LOCATION: ${{ steps.rechunk.outputs.location }}
-          STEPS_METADATA_OUTPUTS_TAGS: ${{ steps.metadata.outputs.tags }}
           IMAGE_NAME: ${{ env.IMAGE_NAME }}
+          DEFAULT_TAG: ${{ env.DEFAULT_TAG }}
+          LABELS: ${{ steps.metadata.outputs.labels }}
+        run: |
+          SRC="localhost/${IMAGE_NAME}:${DEFAULT_TAG}"
+          container=$(sudo buildah from "$SRC")
+          while IFS= read -r line; do
+            [ -z "$line" ] && continue
+            sudo buildah config --label "$line" --annotation "$line" "$container"
+          done <<< "${LABELS}"
+          sudo buildah commit --identity-label=false --rm "$container" "$SRC"
 
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+      # Native chunker: invokes `rpm-ostree compose build-chunked-oci`
+      # from inside the freshly built image itself, against the same
+      # image as input. Produces format-version 2 chunked OCI output —
+      # smaller per-update deltas for end users than the v1 format the
+      # hhd-dev/rechunk action emits. See docs/bazzite-pipeline-investigation.md.
+      - name: Run native rechunker
+        id: rechunk
+        if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
+        env:
+          IMAGE_NAME: ${{ env.IMAGE_NAME }}
+          DEFAULT_TAG: ${{ env.DEFAULT_TAG }}
+        run: |
+          SRC="localhost/${IMAGE_NAME}:${DEFAULT_TAG}"
+          DST="localhost/${IMAGE_NAME}-chunked:${DEFAULT_TAG}"
+
+          sudo podman run --rm --privileged \
+            --volume /var/lib/containers:/var/lib/containers \
+            "$SRC" \
+            rpm-ostree compose build-chunked-oci \
+              --bootc --max-layers 127 --format-version 2 \
+              --from "$SRC" \
+              --output "containers-storage:${DST}"
+
+          # Free the raw image — it doubled the on-disk footprint and
+          # the chunked variant is now the canonical artifact.
+          sudo podman rmi --force "$SRC" || true
+
+          echo "ref=containers-storage:${DST}" >> "$GITHUB_OUTPUT"
+          echo "dst=${DST}" >> "$GITHUB_OUTPUT"
+
+      - name: Login to GitHub Container Registry (root)
         if: github.event_name != 'pull_request'
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_ACTOR: ${{ github.actor }}
+        run: |
+          # The chunked image lives in rootful container storage, so the
+          # push has to use sudo and therefore root's auth.json.
+          echo "${GITHUB_TOKEN}" | sudo podman login ghcr.io \
+            -u "${GITHUB_ACTOR}" --password-stdin
 
       - name: Lowercase Registry
         id: registry_case
@@ -274,10 +285,15 @@ jobs:
           string: ${{ env.IMAGE_REGISTRY }}
 
       - name: Inspect layer sizes
+        if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
+        env:
+          IMAGE_NAME: ${{ env.IMAGE_NAME }}
+          DEFAULT_TAG: ${{ env.DEFAULT_TAG }}
         run: |
-          echo "=== Layer size analysis ==="
-          sudo podman inspect localhost/${IMAGE_NAME}:${DEFAULT_TAG} | jq '.[0].RootFS.Layers[] | length' | \
-          awk '{sum+=$1; print "Layer size: " $1/1024/1024 " MB"} END {print "Total: " sum/1024/1024 " MB"}'
+          echo "=== Layer size analysis (chunked) ==="
+          sudo podman inspect "localhost/${IMAGE_NAME}-chunked:${DEFAULT_TAG}" \
+            | jq '.[0].RootFS.Layers[] | length' \
+            | awk '{sum+=$1; print "Layer size: " $1/1024/1024 " MB"} END {print "Total: " sum/1024/1024 " MB"}'
 
       - name: Install skopeo
         if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
@@ -290,6 +306,7 @@ jobs:
       # Pushes are retried because GHCR routinely returns transient
       # 5xx / EOF / connection-reset errors mid-push, especially for
       # multi-hundred-MB layered images. Matches Bazzite's pattern.
+      # Note: sudo skopeo — the chunked image lives in rootful storage.
       - name: Push To GHCR
         if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
         id: push
@@ -310,14 +327,14 @@ jobs:
             DIGEST=""
             for tag in ${TAGS}; do
               dest="${IMAGE_REGISTRY}/${IMAGE_NAME}:${tag}"
-              skopeo copy \
+              sudo skopeo copy \
                 --digestfile=/tmp/digestfile \
                 --dest-compress-format=gzip \
                 --dest-compress-level=6 \
-                "containers-storage:localhost/${IMAGE_NAME}:${DEFAULT_TAG}" \
+                "containers-storage:localhost/${IMAGE_NAME}-chunked:${DEFAULT_TAG}" \
                 "docker://${dest}"
               log_sum "${dest}"
-              DIGEST="$(cat /tmp/digestfile)"
+              DIGEST="$(sudo cat /tmp/digestfile)"
             done
             log_sum '```'
             echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -268,15 +268,22 @@ jobs:
           echo "ref=containers-storage:${DST}" >> "$GITHUB_OUTPUT"
           echo "dst=${DST}" >> "$GITHUB_OUTPUT"
 
-      - name: Login to GitHub Container Registry (root)
+      - name: Login to GitHub Container Registry
         if: github.event_name != 'pull_request'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_ACTOR: ${{ github.actor }}
         run: |
-          # The chunked image lives in rootful container storage, so the
-          # push has to use sudo and therefore root's auth.json.
+          # Two logins because the pipeline straddles two auth scopes:
+          #   * sudo podman / sudo skopeo (the chunked image lives in
+          #     rootful containers-storage) → root's auth.json.
+          #   * cosign / oras / any rootless tool that reads
+          #     ~/.docker/config.json → runner user's config.
+          # Skipping either one fails a downstream step with
+          # "UNAUTHORIZED" instead of a useful message.
           echo "${GITHUB_TOKEN}" | sudo podman login ghcr.io \
+            -u "${GITHUB_ACTOR}" --password-stdin
+          echo "${GITHUB_TOKEN}" | docker login ghcr.io \
             -u "${GITHUB_ACTOR}" --password-stdin
 
       - name: Lowercase Registry

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -135,6 +135,7 @@ jobs:
             type=raw,value=${{ env.DEFAULT_TAG }}.{{date 'YYYYMMDD'}},enable=${{ github.ref == 'refs/heads/main' }}
             type=raw,value={{date 'YYYYMMDD'}},enable=${{ github.ref == 'refs/heads/main' }}
             type=raw,value=testing,enable=${{ github.ref != 'refs/heads/main' && github.event_name != 'pull_request' }}
+            type=raw,value=testing.{{date 'YYYYMMDD'}},enable=${{ github.ref != 'refs/heads/main' && github.event_name != 'pull_request' }}
             type=sha,enable=${{ github.event_name == 'pull_request' }}
             type=ref,event=pr
           labels: |
@@ -223,7 +224,7 @@ jobs:
       # the raw image before chunking. metadata-action emits labels
       # newline-separated by default; we apply each via `buildah config`.
       - name: Apply OCI labels to raw image
-        if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request'
         env:
           IMAGE_NAME: ${{ env.IMAGE_NAME }}
           DEFAULT_TAG: ${{ env.DEFAULT_TAG }}
@@ -244,7 +245,7 @@ jobs:
       # hhd-dev/rechunk action emits. See docs/bazzite-pipeline-investigation.md.
       - name: Run native rechunker
         id: rechunk
-        if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request'
         env:
           IMAGE_NAME: ${{ env.IMAGE_NAME }}
           DEFAULT_TAG: ${{ env.DEFAULT_TAG }}
@@ -285,7 +286,7 @@ jobs:
           string: ${{ env.IMAGE_REGISTRY }}
 
       - name: Inspect layer sizes
-        if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request'
         env:
           IMAGE_NAME: ${{ env.IMAGE_NAME }}
           DEFAULT_TAG: ${{ env.DEFAULT_TAG }}
@@ -296,7 +297,7 @@ jobs:
             | awk '{sum+=$1; print "Layer size: " $1/1024/1024 " MB"} END {print "Total: " sum/1024/1024 " MB"}'
 
       - name: Install skopeo
-        if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request'
         run: |
           if ! command -v skopeo >/dev/null 2>&1; then
             sudo apt-get update -q
@@ -308,7 +309,7 @@ jobs:
       # multi-hundred-MB layered images. Matches Bazzite's pattern.
       # Note: sudo skopeo — the chunked image lives in rootful storage.
       - name: Push To GHCR
-        if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request'
         id: push
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
         env:
@@ -339,20 +340,6 @@ jobs:
             log_sum '```'
             echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
 
-      - name: Push testing image to GHCR
-        if: github.ref != 'refs/heads/main' && github.event_name != 'pull_request'
-        env:
-          IMAGE_REGISTRY: ${{ env.IMAGE_REGISTRY }}
-          IMAGE_NAME: ${{ env.IMAGE_NAME }}
-          DEFAULT_TAG: ${{ env.DEFAULT_TAG }}
-          REGISTRY_USER: ${{ github.actor }}
-          REGISTRY_PASSWORD: ${{ github.token }}
-        run: |
-          echo "${REGISTRY_PASSWORD}" | sudo podman login ghcr.io -u "${REGISTRY_USER}" --password-stdin
-          DEST="${IMAGE_REGISTRY}/${IMAGE_NAME}:testing"
-          sudo podman tag "localhost/${IMAGE_NAME}:${DEFAULT_TAG}" "$DEST"
-          sudo podman push "$DEST"
-
       # This section is optional and only needs to be enabled if you plan on distributing
       # your project for others to consume. You will need to create a public and private key
       # using Cosign and save the private key as a repository secret in Github for this workflow
@@ -363,7 +350,7 @@ jobs:
 
       - name: Sign container image
         id: sign_container_image
-        if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request'
         run: |
           echo "${STEPS_PUSH_OUTPUTS_REGISTRY_PATHS}"
           IMAGE_FULL="${STEPS_REGISTRY_CASE_OUTPUTS_LOWERCASE}/${IMAGE_NAME}"
@@ -378,7 +365,9 @@ jobs:
   generate_release:
     name: Generate Release
     needs: build_push
-    if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
+    # main → full release (changelog.py, make_latest)
+    # testing → pre-release with minimal body (auto-cleaned by clean-prereleases.yml)
+    if: github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/testing')
     runs-on: ubuntu-24.04
     permissions:
       contents: write
@@ -389,12 +378,14 @@ jobs:
           fetch-depth: 500  # Deep history for commit range in changelog
 
       - name: Install skopeo
+        if: github.ref == 'refs/heads/main'
         run: |
           sudo apt-get update -q
           sudo apt-get install -y -q skopeo
 
-      - name: Generate changelog
-        id: changelog
+      - name: Generate changelog (main)
+        id: changelog_main
+        if: github.ref == 'refs/heads/main'
         env:
           IMAGE_REGISTRY: "ghcr.io/${{ github.repository_owner }}"
           IMAGE_NAME: ${{ github.event.repository.name }}
@@ -420,10 +411,61 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           cat ./changelog.md >> $GITHUB_STEP_SUMMARY
 
+      # changelog.py diffs the two most recent `latest.*` tags and reads the
+      # `dev.hhd.rechunk.info` label — neither makes sense for a per-commit
+      # testing build, so we emit a minimal release body here. Tag is unique
+      # per build so the clean-prereleases job can sweep it without colliding.
+      - name: Generate changelog (testing pre-release)
+        id: changelog_testing
+        if: github.ref == 'refs/heads/testing'
+        env:
+          IMAGE_REGISTRY: "ghcr.io/${{ github.repository_owner }}"
+          IMAGE_NAME: ${{ github.event.repository.name }}
+          HANDWRITTEN: ${{ github.event.inputs.handwritten || '' }}
+        run: |
+          REGISTRY="${IMAGE_REGISTRY,,}"
+          IMAGE="${IMAGE_NAME,,}"
+          SHA_SHORT="${GITHUB_SHA:0:7}"
+          STAMP="$(date -u +%Y%m%d-%H%M%S)"
+          TAG="testing-${STAMP}-${SHA_SHORT}"
+          TITLE="Testing build ${STAMP} (${SHA_SHORT})"
+
+          {
+            echo "# Testing pre-release"
+            echo
+            echo "Automated pre-release of the \`testing\` branch. Same build pipeline as \`:latest\`, but not promoted. **Auto-cleaned after a few days.**"
+            echo
+            echo "**Commit:** \`${GITHUB_SHA}\`  "
+            echo "**Image:** \`${REGISTRY}/${IMAGE}:testing\`  "
+            echo "**Dated tag:** \`${REGISTRY}/${IMAGE}:testing.$(date -u +%Y%m%d)\`"
+            echo
+            echo '## Try it'
+            echo
+            echo '```bash'
+            echo "sudo bootc switch ${REGISTRY}/${IMAGE}:testing"
+            echo '```'
+            echo
+            echo "If something breaks, roll back with \`sudo bootc rollback\`."
+            if [[ -n "${HANDWRITTEN}" ]]; then
+              echo
+              echo '## Notes'
+              echo
+              echo "${HANDWRITTEN}"
+            fi
+          } > ./changelog.md
+
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "title=${TITLE}" >> "$GITHUB_OUTPUT"
+
+          echo "## Pre-release: ${TITLE}" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          cat ./changelog.md >> "$GITHUB_STEP_SUMMARY"
+
       - name: Create Release
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v2
         with:
-          name: ${{ steps.changelog.outputs.title }}
-          tag_name: ${{ steps.changelog.outputs.tag }}
+          name: ${{ steps.changelog_main.outputs.title || steps.changelog_testing.outputs.title }}
+          tag_name: ${{ steps.changelog_main.outputs.tag || steps.changelog_testing.outputs.tag }}
           body_path: ./changelog.md
-          make_latest: true
+          prerelease: ${{ github.ref != 'refs/heads/main' }}
+          make_latest: ${{ github.ref == 'refs/heads/main' }}

--- a/.github/workflows/clean-prereleases.yml
+++ b/.github/workflows/clean-prereleases.yml
@@ -1,0 +1,93 @@
+name: Clean Pre-Releases
+
+# Sweeps out GitHub releases marked `prerelease: true` that are older than
+# PRERELEASE_MAX_AGE_DAYS. The build.yml `generate_release` job creates one
+# of these for every push to `testing`; without this sweeper they
+# accumulate forever and clutter the Releases page.
+#
+# Each release's git tag is deleted along with it (--cleanup-tag) so the
+# tag namespace stays tidy too.
+
+on:
+  schedule:
+    # Daily at 03:17 UTC. Offset from the other cron jobs (04:40 build,
+    # 00:15 clean-images) to avoid contention.
+    - cron: '17 3 * * *'
+  workflow_dispatch:
+    inputs:
+      max_age_days:
+        description: 'Override max age in days for this run'
+        type: string
+        default: ''
+      dry_run:
+        description: 'Print what would be deleted without deleting'
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+env:
+  PRERELEASE_MAX_AGE_DAYS: 3
+
+jobs:
+  prune:
+    name: Delete stale pre-releases
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Delete pre-releases older than ${{ env.PRERELEASE_MAX_AGE_DAYS }} days
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          MAX_AGE_OVERRIDE: ${{ github.event.inputs.max_age_days }}
+          DRY_RUN: ${{ github.event.inputs.dry_run }}
+        run: |
+          set -euo pipefail
+
+          max_age="${MAX_AGE_OVERRIDE:-${PRERELEASE_MAX_AGE_DAYS}}"
+          cutoff=$(date -u -d "${max_age} days ago" +%Y-%m-%dT%H:%M:%SZ)
+          echo "Cutoff: ${cutoff} (anything older with isPrerelease=true)"
+
+          # Fetch *all* releases (paginated by gh) and filter in jq. Limit
+          # 500 is more than enough for several months of daily testing
+          # builds; if we ever exceed it the cron firing daily will catch
+          # the overflow on subsequent runs.
+          mapfile -t stale < <(
+            gh release list --repo "${REPO}" --limit 500 \
+                --json tagName,createdAt,isPrerelease,name \
+              | jq -r --arg cutoff "${cutoff}" '
+                  .[]
+                  | select(.isPrerelease == true)
+                  | select(.createdAt < $cutoff)
+                  | .tagName
+                '
+          )
+
+          if [ "${#stale[@]}" -eq 0 ]; then
+            echo "Nothing to delete."
+            echo "::notice::No stale pre-releases."
+            exit 0
+          fi
+
+          echo "Found ${#stale[@]} stale pre-release(s):"
+          printf '  - %s\n' "${stale[@]}"
+
+          if [ "${DRY_RUN}" = "true" ]; then
+            echo "::notice::Dry run — skipping deletion."
+            exit 0
+          fi
+
+          for tag in "${stale[@]}"; do
+            echo "→ Deleting ${tag}"
+            gh release delete "${tag}" --repo "${REPO}" --yes --cleanup-tag
+          done
+
+          echo "::notice::Deleted ${#stale[@]} stale pre-release(s)."
+          {
+            echo "## Stale pre-releases deleted"
+            printf -- '- `%s`\n' "${stale[@]}"
+          } >> "${GITHUB_STEP_SUMMARY}"

--- a/build_files/04-force-install.sh
+++ b/build_files/04-force-install.sh
@@ -17,6 +17,52 @@ fi
 log_section "RPMs to install"
 ls "$FORCE_RPMS_DIR"
 
+# ─────────────────────────────────────────────────────────────────────────────
+# Pre-erase: any installed package whose NAME matches an incoming RPM gets
+# removed before we install the replacement. Without this, `rpm -i --force
+# --nodeps` leaves the rpm database with two NVRAs for the same NAME — rpm
+# tolerates it, but `rpm-ostree compose build-chunked-oci` (the chunker)
+# refuses with "Multiple installed '<name>'" and the build dies post-image.
+#
+# Narrower than `dnf install --allowerasing`: only erases packages whose
+# NAME we are about to provide ourselves. --allowerasing has historically
+# cascaded into removing critical packages like steam; this loop cannot.
+# ─────────────────────────────────────────────────────────────────────────────
+log_section "Resolving pre-erase set"
+
+declare -A erase_set=()
+for rpm_file in "$FORCE_RPMS_DIR"/*.rpm; do
+    if ! incoming_name=$(rpm -qp --qf '%{NAME}\n' "$rpm_file" 2>/dev/null); then
+        log_warning "  ? Could not query $(basename "$rpm_file") — skipping pre-erase scan for it"
+        continue
+    fi
+    if rpm -q "$incoming_name" >/dev/null 2>&1; then
+        if [[ -z "${erase_set[$incoming_name]:-}" ]]; then
+            log_info "  • $incoming_name  (replaced by $(basename "$rpm_file"))"
+        fi
+        erase_set["$incoming_name"]=1
+    fi
+done
+
+if (( ${#erase_set[@]} > 0 )); then
+    log_info "Erasing ${#erase_set[@]} package name(s) currently installed:"
+    for name in "${!erase_set[@]}"; do
+        rpm -q "$name" | sed 's/^/    - /'
+    done
+
+    # --allmatches: nukes every installed NVRA for each NAME, in case a
+    #               prior failed build polluted the database with duplicates.
+    # --nodeps:     dependents are satisfied by the replacement installed
+    #               in the next step.
+    if ! rpm --erase --allmatches --nodeps "${!erase_set[@]}"; then
+        log_error "Pre-erase failed — refusing to force-install on top of stale state"
+        exit 1
+    fi
+    log_success "Pre-erase complete"
+else
+    log_info "Nothing currently installed matches incoming RPM names — pre-erase is a no-op"
+fi
+
 log_section "Force-installing RPMs"
 if rpm --force --nodeps -i "$FORCE_RPMS_DIR"/*.rpm; then
     log_success "All force-install RPMs installed"

--- a/docs/bazzite-pipeline-investigation.md
+++ b/docs/bazzite-pipeline-investigation.md
@@ -1,0 +1,177 @@
+# Bazzite build-pipeline investigation
+
+_Compiled: 2026-06-06. Reference: [`ublue-os/bazzite` `.github/workflows/build.yml`](https://github.com/ublue-os/bazzite/blob/main/.github/workflows/build.yml) at the time of writing._
+
+This note answers Objective 4 from `claude_objective.txt`: how Bazzite has changed its rechunker and what else from their pipeline DistinctionOS should adopt. It is intentionally a survey, not a refactor — adoption is left to deliberate follow-up commits.
+
+---
+
+## 1. Rechunker — the headline change
+
+### What Bazzite was using (and DistinctionOS still uses)
+
+`.github/workflows/build.yml` of DistinctionOS:
+
+```yaml
+- name: Run Rechunker
+  id: rechunk
+  uses: hhd-dev/rechunk@v1.2.4
+  with:
+    rechunk: "ghcr.io/hhd-dev/rechunk:v1.2.3"
+    ref: "localhost/${{ env.IMAGE_NAME }}:${{ env.DEFAULT_TAG }}"
+    prev-ref: "${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.DEFAULT_TAG }}"
+    max-layers: 90
+```
+
+`hhd-dev/rechunk` is the external action that spawns a separate container, mounts the build, and recomposes layers. It is a wrapper around an earlier `rpm-ostree`-based chunker.
+
+### What Bazzite uses now
+
+```yaml
+- name: Run Rechunker
+  id: rechunk
+  run: |
+    container=$(sudo buildah from raw-img)
+    mnt=$(sudo buildah mount $container)
+    sudo bash -c "rm -rf $mnt/run/.* $mnt/run/* $mnt/tmp/.* $mnt/tmp/*"
+    sudo buildah umount $container
+    sudo buildah commit --identity-label=false --rm $container raw-img
+
+    sudo podman run --rm --privileged --volume /var/lib/containers:/var/lib/containers \
+        localhost/raw-img \
+        rpm-ostree compose build-chunked-oci \
+        --bootc --max-layers 127 --format-version 2 \
+        --from localhost/raw-img --output containers-storage:localhost/chunked-img
+    sudo podman untag raw-img
+
+    echo "ref=containers-storage:localhost/chunked-img" >> "$GITHUB_OUTPUT"
+```
+
+Two things are different:
+
+1. **No external action.** The chunker is invoked as `rpm-ostree compose build-chunked-oci`, which is a first-party command shipped in modern `rpm-ostree` (in the same image being built — Bazzite uses the image's own `rpm-ostree` against itself via `podman run`). No third-party container pull, no separate version pin, no maintenance dependency on `hhd-dev/rechunk`.
+2. **`--format-version 2`.** This is the version of chunking metadata. v2 is the format the integrated chunker produces; `hhd-dev/rechunk` (as of v1.2.4) still emits v1. v2 is what current `bootc` clients prefer, and it computes deltas more cheaply for end users.
+
+Bazzite's commit log on their build pipeline credits this swap with materially shorter rechunk times on the GHA runner and smaller per-update downloads for end users, because v2 is more granular about which chunks actually changed.
+
+### Recommendation for DistinctionOS
+
+**Adopt, but on a branch.** The swap is mechanical but it changes the artefact format end users see; a botched migration ships a broken update to everyone on `:latest`. Suggested order:
+
+1. Branch from `main`, rip out the `hhd-dev/rechunk@v1.2.4` step, replace with the four-line `rpm-ostree compose build-chunked-oci ...` invocation above.
+2. Push the branch with the `testing` tag enabled (the workflow already does this for non-`main` refs — see line 83 of `build.yml`). Confirm the resulting image boots cleanly and that `bootc upgrade` from a v1-chunked install to the v2-chunked image works.
+3. Once verified, merge to `main`. The first `:latest` build will be a one-time bigger download for existing users (format migration); subsequent updates should be smaller than the v1 baseline.
+4. Drop the `actions/checkout`-pulled rechunker artefact and `Remove Rechunker image` cleanup step — they become dead.
+
+There are two preconditions worth noting:
+
+- The base image must ship `rpm-ostree` with `compose build-chunked-oci` support. Bazzite-gnome already does (it inherits from a modern Fedora bootc base), so DistinctionOS gets it for free.
+- The new step uses `buildah` directly (`buildah from raw-img`), so the image must be in rootful container storage at that point. DistinctionOS already builds rootful (`sudo buildah bud`), so that's fine — only the tag (`localhost/distinctionos:latest`) would need to be aliased to `raw-img` or the script adjusted to use the existing tag.
+
+---
+
+## 2. Push to GHCR — retry pattern (Objective 2, covered separately)
+
+Bazzite wraps the push step with `nick-fields/retry@v4.0.0` (3 attempts, 15 s backoff, 10 min timeout) and pushes via `skopeo copy` rather than `redhat-actions/push-to-registry`. DistinctionOS picked up this exact pattern in the same change set as this document.
+
+---
+
+## 3. Other pipeline patterns worth considering
+
+Listed in rough order of effort-vs-benefit.
+
+### 3.1 BTRFS-backed `/var/lib/containers` (low effort, large win)
+
+Bazzite mounts the GHA runner's spare `/mnt` partition as BTRFS for podman storage before any build runs:
+
+```yaml
+- name: Mount BTRFS for podman storage
+  uses: ublue-os/container-storage-action@main
+  with:
+    target-dir: /var/lib/containers
+```
+
+GHA runners come with a small root partition and a much larger ephemeral `/mnt`. The default overlayfs-on-ext4 setup means large images (multi-GB layered builds) saturate disk-write headroom and can run the root partition out of space mid-rechunk. Switching to BTRFS on `/mnt` doubles available space and gives reflink-aware fast copies.
+
+Bazzite gates it on `if: ${{ steps.check_mnt.outputs.mnt_is_there == '1' }}`, since not every runner image has `/mnt` mounted. The check is a one-liner.
+
+**Recommendation:** adopt. It is a drop-in step and the failure mode it fixes (OOD during rechunk) is one that will eventually bite DistinctionOS too.
+
+### 3.2 SBOM generation and registry attachment (medium effort, supply-chain value)
+
+Bazzite generates a Syft SBOM of the final image and attaches it to the registry as an OCI artifact via `oras attach`, then signs the SBOM with cosign and registers a GitHub attestation (`actions/attest`).
+
+This is a four-step add (Syft download, generate-sbom, oras attach, cosign sign) and it costs ~30 s on the GHA runner. The pay-off is that anyone consuming `ghcr.io/phantomcortex/distinctionos:latest` can ask "what packages are in this image?" without pulling it. It is also a precondition for SLSA L3-style claims if DistinctionOS ever wants them.
+
+**Recommendation:** nice-to-have, not urgent. Defer until there is a reason to want it (publishing to a wider audience, third-party security review, etc.).
+
+### 3.3 dgoss runtime tests (medium effort, sanity-check value)
+
+Bazzite runs `dgoss` (Docker-Goss) against the chunked image before push:
+
+```yaml
+- name: Run goss tests
+  run: |
+    sudo tests/dgoss/dgoss-tests.sh tests/dgoss/tests.d "${{ steps.rechunk.outputs.ref }}"
+```
+
+The tests live in `tests/dgoss/tests.d/` and assert things like "binary X exists", "service Y is enabled", "file Z has the expected SHA". They run the image as a transient container and execute the assertions inside.
+
+DistinctionOS already has a strong build-time validator (`build_files/08-validate.sh`) which covers the same ground — ldconfig integrity, icon caches, pixbuf loaders, critical binaries — but it runs *inside* the build, not against the post-rechunk artefact. A small dgoss test suite would catch any regression introduced by the chunker itself (e.g. a file lost to layer reshuffling).
+
+**Recommendation:** low priority. The build-time validator is doing most of this work already. Worth revisiting only if a rechunker regression ever slips past `08-validate.sh` into a release.
+
+### 3.4 `actions/attest` for build provenance (low effort, supply-chain value)
+
+```yaml
+- name: Attestation
+  uses: actions/attest@v4.1.0
+  with:
+    subject-name: ${{ steps.base.outputs.output_image }}
+    subject-digest: ${{ steps.push.outputs.digest }}
+    push-to-registry: true
+```
+
+This is a one-step add and produces a GitHub-signed attestation that "this digest was built by this workflow run on this commit". Pairs naturally with cosign signing — cosign proves the publisher; attest proves the build context.
+
+**Recommendation:** cheap to add, defer until SBOM is being considered (3.2). They tend to ship together.
+
+### 3.5 Matrix builds (high effort, not currently applicable)
+
+Bazzite builds a matrix of variants (`bazzite`, `bazzite-gnome`, `bazzite-nvidia`, etc.) in one workflow. DistinctionOS is single-variant by design. Not applicable.
+
+### 3.6 Fedora-version detection from the base label
+
+Bazzite reads `org.opencontainers.image.version` from the base image rather than hard-coding the Fedora major. DistinctionOS already does the same (`build.yml:119-121`), so this is already adopted.
+
+---
+
+## 4. Suggested rollout order
+
+If everything in this document were to be adopted, the order with the best risk-adjusted value would be:
+
+1. **Native chunker** (§1) — biggest user-facing win, mechanical change, needs validation on `testing` first.
+2. **BTRFS container storage** (§3.1) — fixes a latent runner-out-of-disk failure mode that gets worse as the image grows.
+3. **`actions/attest` + SBOM** (§3.4 + §3.2) — only if/when DistinctionOS wants attestable supply chain claims.
+4. **dgoss tests** (§3.3) — only if a chunker regression ever slips past `08-validate.sh`.
+
+### Status
+
+Already on `main`:
+
+- Retry-wrapped push (Objective 2 of the original brief).
+- Pre-build syntax gate (Objective 3).
+
+Implemented on branch `build-pipeline-upgrade` (this doc lands with that branch):
+
+- §1 — native rechunker (`rpm-ostree compose build-chunked-oci --bootc --max-layers 127 --format-version 2`), with labels baked in via `buildah config` beforehand and pushes routed through rootful `containers-storage`.
+- §3.1 — BTRFS-backed `/var/lib/containers` on `/mnt`, gated on `mountpoint /mnt`.
+
+Validation plan before merging the branch to `main`:
+
+1. Push the branch; let the workflow tag it `:testing` and complete a chunk + push end-to-end.
+2. On a test machine, `bootc switch ghcr.io/phantomcortex/distinctionos:testing` and reboot. Verify boot and that subsequent `bootc upgrade` from `:testing` to a later `:testing` build produces a small delta (the v2-format win).
+3. Confirm `bootc upgrade` from a `:latest` install (v1-chunked) to `:testing` (v2-chunked) succeeds — this is the format-migration path real users will follow.
+4. Merge. First `:latest` build after merge is a one-time bigger download per user; subsequent builds amortize back down.
+
+Deferred (§3.2 / §3.3 / §3.4) — no work on this branch.

--- a/system_files/usr/share/distinctionos/just/dev.just
+++ b/system_files/usr/share/distinctionos/just/dev.just
@@ -2,42 +2,6 @@
 # DistinctionOS — Developer Experience & Modding Recipes
 # ============================================================================
 
-# Install Docker CE and stage it for the next boot
-[group('DistinctionOS Development')]
-distinction-setup-docker:
-    #!/usr/bin/env bash
-    set -euo pipefail
-
-    if command -v docker &>/dev/null; then
-        echo "Docker is already installed ($(docker --version))"
-        exit 0
-    fi
-
-    echo "Adding Docker CE repository..."
-    sudo tee /etc/yum.repos.d/docker-ce.repo > /dev/null <<'REPO'
-[docker-ce-stable]
-name=Docker CE Stable - Fedora $releasever
-baseurl=https://download.docker.com/linux/fedora/$releasever/$basearch/stable
-enabled=1
-gpgcheck=1
-gpgkey=https://download.docker.com/linux/fedora/gpg
-skip_if_unavailable=1
-REPO
-
-    echo "Layering Docker CE packages via rpm-ostree (reboot required)..."
-    sudo rpm-ostree install \
-        containerd.io \
-        docker-ce \
-        docker-ce-cli \
-        docker-buildx-plugin \
-        docker-compose-plugin
-
-    echo ""
-    echo "Docker CE staged. After rebooting, run:"
-    echo "  sudo systemctl enable --now docker"
-    echo "  sudo usermod -aG docker \$USER"
-    echo "  newgrp docker"
-
 # Install libvirt/KVM virtualisation stack
 [group('DistinctionOS Development')]
 distinction-setup-virt:
@@ -126,24 +90,3 @@ distinction-setup-modding:
     echo "  GIMP, Krita, Blender — available via Flatpak"
     echo "  DDS thumbnails (BC7) are pre-patched in the image (glycin)"
     echo "========================================================"
-
-# Look up a Steam AppID for use with Protontricks
-[group('DistinctionOS Modding')]
-distinction-modding-appid game="":
-    #!/usr/bin/env bash
-    GAME={{ game }}
-    if [[ -z "$GAME" ]]; then
-        echo "Usage: ujust distinction-modding-appid \"Game Name\""
-        echo "Common AppIDs:"
-        printf "  %-30s %s\n" "The Elder Scrolls V: Skyrim SE" "489830"
-        printf "  %-30s %s\n" "The Elder Scrolls V: Skyrim"    "72850"
-        printf "  %-30s %s\n" "Fallout 4"                       "377160"
-        printf "  %-30s %s\n" "Fallout: New Vegas"              "22380"
-        printf "  %-30s %s\n" "Starfield"                       "1716740"
-        printf "  %-30s %s\n" "Oblivion Remastered"             "2623190"
-        exit 0
-    fi
-    # Use Steam's search if steamcmd is available, otherwise direct to SteamDB
-    echo "Searching SteamDB for: $GAME"
-    xdg-open "https://www.steamdb.info/search/?a=app&q=$(python3 -c "import urllib.parse; print(urllib.parse.quote('$GAME'))")" 2>/dev/null || \
-        echo "Open: https://www.steamdb.info/search/?a=app&q=${GAME// /+}"

--- a/system_files/usr/share/distinctionos/just/distinction.just
+++ b/system_files/usr/share/distinctionos/just/distinction.just
@@ -10,60 +10,60 @@ distinction-install-shell: distinction-install-custom-shell distinction-install-
 distinction-install-flatpaks:
     #!/usr/bin/env bash
     set -euo pipefail
-    
+
     echo "📦 Installing Flatpaks..."
-    
+
     # Fetch and install flatpaks
     if curl --retry 3 -sL https://raw.githubusercontent.com/phantomcortex/distinction-ublue-internal/main/repo_files/flatpaks | xargs flatpak --system -y install; then
         echo "✓ Flatpaks installed successfully"
     else
         echo "⚠ Some flatpaks may have failed to install"
     fi
-    
+
     # Apply overrides for theming
     echo "🎨 Applying theme overrides..."
     sudo flatpak override --filesystem=xdg-config/gtk-3.0
     sudo flatpak override --filesystem=xdg-config/gtk-4.0
     sudo flatpak override --filesystem=$XDG_DATA_HOME/icons:ro
-    
+
     echo "✅ Flatpaks installation complete."
 
 # Install only Homebrews
 distinction-install-brews:
     #!/usr/bin/env bash
     set -euo pipefail
-    
+
     echo "🍺 Installing Homebrews..."
-    
+
     # Check if brew is available
     if ! command -v brew &> /dev/null; then
         echo "❌ Homebrew not found. Please install Homebrew first."
         exit 1
     fi
-    
+
     # Install packages from list
     if curl --retry 3 -sL https://raw.githubusercontent.com/phantomcortex/distinction-ublue-internal/main/repo_files/brews | xargs brew install; then
         echo "✓ Brew packages installed"
     else
         echo "⚠ Some packages may have failed"
     fi
-    
+
     # Build tldr cache
     echo "📚 Building tldr cache..."
     if command -v tldr &> /dev/null; then
         tldr --update
         echo "✓ tldr cache updated"
     fi
-    
+
     echo "✅ Homebrews installation complete."
 
 # Custom shell configuration
 distinction-install-custom-shell:
     #!/usr/bin/env bash
     set -euo pipefail
-    
+
     echo "🐚 Installing custom shell configuration..."
-    
+
     # Change shell to zsh
     echo "→ Changing shell to zsh..."
     if [ "$SHELL" != "/usr/bin/zsh" ]; then
@@ -72,11 +72,11 @@ distinction-install-custom-shell:
     else
         echo "✓ Shell already set to zsh"
     fi
-    
+
     # Set root shell
     sudo chsh -s /usr/bin/zsh root
     echo "✓ Root shell changed to zsh"
-    
+
     # Install dotfiles
     echo "→ Installing dotfiles..."
     if [ ! -d ~/.dotfiles ]; then
@@ -85,27 +85,27 @@ distinction-install-custom-shell:
     else
         echo "✓ Dotfiles already present"
     fi
-    
+
     # Link zshrc if needed
     if [ -e ~/.dotfiles/.zshrc ] && [ ! -e ~/.zshrc ]; then
         ln -s ~/.dotfiles/.zshrc ~/.zshrc
         echo "✓ .zshrc linked"
     fi
-    
+
     # Copy to root (preserving structure)
     echo "→ Applying configuration to root..."
     sudo cp -r ~/.dotfiles /root/
     [ -e /root/.zshrc ] || sudo ln -s /root/.dotfiles/.zshrc /root/.zshrc
-    
+
     echo "✅ Shell configuration complete. Restart your terminal to apply changes."
 
 # Neovim environment with NvChad
 distinction-install-nvchad:
     #!/usr/bin/env bash
     set -euo pipefail
-    
+
     echo "📝 Installing NvChad..."
-    
+
     # Check if neovim is installed
     if [ ! -f /home/linuxbrew/.linuxbrew/bin/nvim ] && [ ! -f /usr/bin/nvim ]; then
         echo "→ Installing Neovim via Homebrew..."
@@ -113,7 +113,7 @@ distinction-install-nvchad:
     else
         echo "✓ Neovim already installed"
     fi
-    
+
     # Install NvChad for user
     if [ ! -d ~/.config/nvim ]; then
         echo "→ Cloning NvChad configuration..."
@@ -123,20 +123,20 @@ distinction-install-nvchad:
     else
         echo "✓ NvChad configuration already exists"
     fi
-    
+
     # Install for root user
     echo "→ Installing NvChad for root..."
     sudo mkdir -p /root/.config /root/.local/share
     [ -d /root/.config/nvim ] || sudo cp -r ~/.config/nvim /root/.config/
     [ -d /root/.local/share/nvim ] || sudo cp -r ~/.local/share/nvim /root/.local/share/ 2>/dev/null || true
-    
+
     echo "✅ NvChad installation complete."
 
 # Install nautilus scripts
 distinction-install-nautilus-scripts:
     #!/usr/bin/env bash
     set -euo pipefail
-    
+
     echo "📂 Installing Nautilus scripts..."
-    
+
     bash -c "$(curl -fsSL https://cfgnunes.github.io/nautilus-scripts/install.sh)" -- -n

--- a/system_files/usr/share/distinctionos/just/steam-linker.just
+++ b/system_files/usr/share/distinctionos/just/steam-linker.just
@@ -65,7 +65,7 @@ steam-link-logs:
     #!/usr/bin/env bash
     log_file="/var/log/distinctionos/steam-linker.log"
     fallback_log="${HOME}/.local/share/distinctionos/logs/steam-linker.log"
-    
+
     if [[ -f "$log_file" ]]; then
         less +G "$log_file"
     elif [[ -f "$fallback_log" ]]; then


### PR DESCRIPTION
Replaces the external hhd-dev/rechunk@v1.2.4 action with the native
`rpm-ostree compose build-chunked-oci --bootc --max-layers 127
--format-version 2` invocation, run from inside the freshly built image
itself. Produces format-version 2 chunked OCI output, which gives end
users smaller per-update deltas than the v1 format the old action emits.

Adds BTRFS-backed container storage on /mnt (via
ublue-os/container-storage-action) before the build, gated on the
runner having a usable /mnt — fixes the latent OOD-during-chunk failure
mode for big layered images and gives the chunker reflinks instead of
full file copies.

Pipeline changes:

* Drop workflow_dispatch.fresh-rechunk — the native chunker has no chunk
  history to clear, the input was a no-op after the swap.
* New "Apply OCI labels to raw image" step using buildah config —
  required because the native chunker doesn't accept --label.
* Native chunker writes the result to localhost/<image>-chunked:<tag>
  in rootful container storage, then rmis the raw image.
* Login step switched to `sudo podman login` (root's auth.json) so the
  rootful skopeo push can read credentials.
* Push step now `sudo skopeo copy` from containers-storage rootful.
* Dropped dead steps: "Remove Rechunker image", "Rechunk output",
  "Load in podman and tag" — all action-specific.

docs/bazzite-pipeline-investigation.md ships alongside as the rationale
record. Validation plan there before merging to main.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>