### PR TITLE
Restore package changelog + add dry_run validation flag

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,11 @@ on:
         description: 'Optional handwritten changelog message for this release'
         type: string
         default: ''
+      dry_run:
+        description: 'Validation run — build only, no push (off=normal, build=stop after build, chunk=stop after rechunk)'
+        type: choice
+        options: ['off', 'build', 'chunk']
+        default: 'off'
 env:
   IMAGE_DESC: "My Customized Bazzite Image"
   IMAGE_KEYWORDS: "bootc,ublue,universal-blue"
@@ -264,7 +269,7 @@ jobs:
       # hhd-dev/rechunk action emits. See docs/bazzite-pipeline-investigation.md.
       - name: Run native rechunker
         id: rechunk
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request' && inputs.dry_run != 'build'
         env:
           IMAGE_NAME: ${{ env.IMAGE_NAME }}
           DEFAULT_TAG: ${{ env.DEFAULT_TAG }}
@@ -312,7 +317,7 @@ jobs:
           string: ${{ env.IMAGE_REGISTRY }}
 
       - name: Inspect layer sizes
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request' && inputs.dry_run != 'build'
         env:
           IMAGE_NAME: ${{ env.IMAGE_NAME }}
           DEFAULT_TAG: ${{ env.DEFAULT_TAG }}
@@ -335,7 +340,7 @@ jobs:
       # multi-hundred-MB layered images. Matches Bazzite's pattern.
       # Note: sudo skopeo — the chunked image lives in rootful storage.
       - name: Push To GHCR
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request' && (inputs.dry_run == '' || inputs.dry_run == 'off')
         id: push
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
         env:
@@ -376,7 +381,7 @@ jobs:
 
       - name: Sign container image
         id: sign_container_image
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request' && (inputs.dry_run == '' || inputs.dry_run == 'off')
         run: |
           echo "${STEPS_PUSH_OUTPUTS_REGISTRY_PATHS}"
           IMAGE_FULL="${STEPS_REGISTRY_CASE_OUTPUTS_LOWERCASE}/${IMAGE_NAME}"
@@ -393,7 +398,7 @@ jobs:
     needs: build_push
     # main → full release (changelog.py, make_latest)
     # testing → pre-release with minimal body (auto-cleaned by clean-prereleases.yml)
-    if: github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/testing')
+    if: github.event_name != 'pull_request' && (inputs.dry_run == '' || inputs.dry_run == 'off') && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/testing')
     runs-on: ubuntu-24.04
     permissions:
       contents: write

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -246,6 +246,15 @@ jobs:
             [ -z "$line" ] && continue
             sudo buildah config --label "$line" --annotation "$line" "$container"
           done <<< "${LABELS}"
+
+          # The native chunker doesn't emit dev.hhd.rechunk.info the way the
+          # old hhd-dev/rechunk action did, so changelog.py loses its package
+          # list. Rebuild that label from the image's RPM database here.
+          pkgs_json=$(sudo buildah run "$container" -- \
+            rpm -qa --qf '%{NAME}\t%{VERSION}-%{RELEASE}\n' \
+            | python3 -c 'import sys, json; print(json.dumps({"packages": dict(l.split("\t", 1) for l in sys.stdin.read().splitlines() if "\t" in l)}))')
+          sudo buildah config --label "dev.hhd.rechunk.info=${pkgs_json}" "$container"
+
           sudo buildah commit --identity-label=false --rm "$container" "$SRC"
 
       # Native chunker: invokes `rpm-ostree compose build-chunked-oci`


### PR DESCRIPTION
## Summary

Two related build-pipeline fixes following the native-chunker migration (#51).

### 1. Restore the package changelog (`970e6e4`)

PR #51 replaced the `hhd-dev/rechunk` action with the native chunker
(`rpm-ostree compose build-chunked-oci`). The old action was the thing that
emitted the **`dev.hhd.rechunk.info`** OCI label — a JSON `{package: version}`
map that `changelog.py` reads (and *only* reads) to build the "Major Packages"
and "Package Changes" tables. The native chunker doesn't emit it, so both
tables went empty. Commits kept showing because they ride a *different* label
(`org.opencontainers.image.revision`), which is still baked in — hence the
"commits yes, packages no" symptom on recent releases.

Verified against the live registry: the label is present on `latest.20260605`
and earlier (~2350 packages), absent on `latest.20260610`/`20260611` — the
first builds after the merge.

**Fix:** regenerate the label from the raw image's RPM database in the existing
"Apply OCI labels" step, matching the format the old action emitted
(`%{VERSION}-%{RELEASE}`). `changelog.py` is unchanged.

> [!NOTE]
> The first post-merge changelog diffs a label-bearing build against the
> previous label-less one, so the "Package Changes" table will list all
> ~2350 packages as added, once. It self-corrects on the following build.

### 2. Add `dry_run` validation flag (`b0616e1`)

New `workflow_dispatch` choice input to validate that the image builds — and
optionally rechunks — cleanly on a manual run, without publishing:

| Choice | Behaviour |
|---|---|
| `off` (default) | Normal build + chunk + push + sign + release |
| `build` | Stops after **Build image (rootful)** |
| `chunk` | Runs through **Run native rechunker**, then stops |

Both stop points skip push, signing, and the release job. Automated
push/schedule/PR runs are unaffected — the `inputs` context is empty for those
events.

> [!NOTE]
> The `dry_run` selector only appears on the Actions tab once this is on `main`
> (GitHub reads `workflow_dispatch` inputs from the default branch).

## Testing

- YAML parses; CI yamllint (line-length disabled) passes clean.
- Embedded Python for the package-map generation tested locally (dedups
  multilib, skips malformed lines).
- Full end-to-end behaviour can only be confirmed on the next `:latest` build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)